### PR TITLE
fix: replace vulnerable xlsx dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "uuid": "^9.0.1",
         "wkhtmltopdf": "^0.4.0",
         "ws": "^8.18.0",
-        "xlsx": "^0.18.5",
+        "xlsx": "npm:@stackline/xlsx@^1.0.6",
         "yjs": "^13.6.30",
         "zxcvbn": "^4.4.2"
       },
@@ -5155,13 +5155,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
       "dev": true,
@@ -7383,13 +7376,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fragment-cache": {
@@ -12872,16 +12858,6 @@
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "dev": true,
@@ -15222,20 +15198,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "dev": true,
@@ -15384,22 +15346,13 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
+      "name": "@stackline/xlsx",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@stackline/xlsx/-/xlsx-1.0.6.tgz",
+      "integrity": "sha512-9huNkQPK7yQGUfO5wXixydxjh0Zi8y+0wBCIMHdrscXrd2AULCp+ck6ZhZNH5FQROL98PLvfxVy5wRSRosjmhg==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
       "engines": {
-        "node": ">=0.8"
+        "node": ">=20"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "uuid": "^9.0.1",
     "wkhtmltopdf": "^0.4.0",
     "ws": "^8.18.0",
-    "xlsx": "^0.18.5",
+    "xlsx": "npm:@stackline/xlsx@^1.0.6",
     "yjs": "^13.6.30",
     "zxcvbn": "^4.4.2"
   },

--- a/tests/integration/xlsx.test.ts
+++ b/tests/integration/xlsx.test.ts
@@ -1,0 +1,25 @@
+import * as XLSX from 'xlsx';
+
+describe('Excel compatibility', () => {
+    it('writes and reads workbooks through the xlsx-compatible API', () => {
+        const rows = [
+            ['Name', 'Score'],
+            ['Ada', 10],
+            ['Linus', 9]
+        ];
+        const worksheet = XLSX.utils.aoa_to_sheet(rows);
+        const workbook = XLSX.utils.book_new();
+
+        XLSX.utils.book_append_sheet(workbook, worksheet, 'Results');
+
+        const file = XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
+        const parsed = XLSX.read(file, { type: 'buffer' });
+        const parsedRows = XLSX.utils.sheet_to_json(parsed.Sheets.Results, {
+            header: 1,
+            raw: true
+        });
+
+        expect(parsed.SheetNames).toEqual(['Results']);
+        expect(parsedRows).toEqual(rows);
+    });
+});


### PR DESCRIPTION
## Summary

- replace `xlsx@0.18.5` with the npm alias `xlsx: npm:@stackline/xlsx@^1.0.6`
- preserve every existing `xlsx` import and the public API used by the application
- refresh the lockfile and remove the old package's unused transitive dependencies
- add an Excel round-trip regression test covering workbook creation, XLSX serialization, parsing, and `sheet_to_json`

## Security

This removes the affected `xlsx@0.18.5` release associated with GHSA-4r6h-8v6p-xvw6 and GHSA-5pgg-2g8v-p4x9. `npm audit --omit=dev` no longer reports either `xlsx` advisory.

Disclosure: I maintain `@stackline/xlsx`, the independent Apache-2.0 fork proposed in #58. The npm alias keeps the dependency name as `xlsx`, so no application imports need to change.

## Validation

- `npm ci --no-audit --no-fund`
- `npm test` - 21 suites passed, 234 tests passed
- `npm run build:web` - production Vite bundle completed, including the dynamically loaded `xlsx` chunk
- tested on Node.js 20; the project CI uses Node.js 24

Thank you, @sunhouy, for reviewing the remediation options and inviting this contribution.

Closes #58